### PR TITLE
Add more strict

### DIFF
--- a/src/Resolvers/ClassNameResolver.php
+++ b/src/Resolvers/ClassNameResolver.php
@@ -32,17 +32,25 @@ class ClassNameResolver implements DependencyResolverInterface
     {
         $result = [];
         foreach ($reflectionFunction->getParameters() as $parameter) {
-            $result[] = $this->resolveParameter($parameter);
+            $result[] = $this->resolveParameter($parameter, $reflectionFunction);
         }
         return $result;
     }
 
-    private function resolveParameter(\ReflectionParameter $parameter): DefinitionInterface
+    private function resolveParameter(\ReflectionParameter $parameter, \ReflectionFunctionAbstract $function): DefinitionInterface
     {
         $type = $parameter->getType();
 
+        if (($type !== null && $type->allowsNull()) || $function->isInternal()){
+            return new ValueDefinition(
+                $parameter->isDefaultValueAvailable()
+                    ? $parameter->getDefaultValue()
+                    : null
+            );
+        }
+
         if ($parameter->isOptional()) {
-            return new ValueDefinition($parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null);
+            return new ValueDefinition($parameter->getDefaultValue());
         }
 
         if ($type !== null && !$type->isBuiltin()) {

--- a/src/Resolvers/ClassNameResolver.php
+++ b/src/Resolvers/ClassNameResolver.php
@@ -2,8 +2,8 @@
 
 namespace Yiisoft\Factory\Resolvers;
 
-use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Definitions\ClassDefinition;
+use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Definitions\InvalidDefinition;
 use Yiisoft\Factory\Definitions\ValueDefinition;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
@@ -40,19 +40,16 @@ class ClassNameResolver implements DependencyResolverInterface
     private function resolveParameter(\ReflectionParameter $parameter): DefinitionInterface
     {
         $type = $parameter->getType();
-        $hasDefault = $parameter->isOptional() || $parameter->isDefaultValueAvailable() || (isset($type) && $type->allowsNull());
 
-        if (!$hasDefault && $type === null) {
-            return new InvalidDefinition();
+        if ($parameter->isOptional()) {
+            return new ValueDefinition($parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null);
         }
 
-        // Our parameter has a class type hint
         if ($type !== null && !$type->isBuiltin()) {
             return new ClassDefinition($type->getName(), $type->allowsNull());
         }
 
-        // Our parameter does not have a class type hint and either has a default value or is nullable.
-        return new ValueDefinition($parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null);
+        return new InvalidDefinition();
     }
 
     /**

--- a/tests/Support/HasNoDefaultValue/ArrayArgument.php
+++ b/tests/Support/HasNoDefaultValue/ArrayArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class ArrayArgument
+{
+    public function __construct(array $arg)
+    {
+    }
+}

--- a/tests/Support/HasNoDefaultValue/BooleanArgument.php
+++ b/tests/Support/HasNoDefaultValue/BooleanArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class BooleanArgument
+{
+    public function __construct(bool $arg)
+    {
+    }
+}

--- a/tests/Support/HasNoDefaultValue/CallableArgument.php
+++ b/tests/Support/HasNoDefaultValue/CallableArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class CallableArgument
+{
+    public function __construct(callable $arg)
+    {
+    }
+}

--- a/tests/Support/HasNoDefaultValue/IntArgument.php
+++ b/tests/Support/HasNoDefaultValue/IntArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class IntArgument
+{
+    public function __construct(int $arg)
+    {
+    }
+}

--- a/tests/Support/HasNoDefaultValue/ObjectArgument.php
+++ b/tests/Support/HasNoDefaultValue/ObjectArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class ObjectArgument
+{
+    public function __construct(object $arg)
+    {
+    }
+}

--- a/tests/Support/HasNoDefaultValue/StringArgument.php
+++ b/tests/Support/HasNoDefaultValue/StringArgument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Support\HasNoDefaultValue;
+
+class StringArgument
+{
+    public function __construct(string $arg)
+    {
+    }
+}

--- a/tests/Unit/Resolvers/ClassNameResolverTest.php
+++ b/tests/Unit/Resolvers/ClassNameResolverTest.php
@@ -3,13 +3,20 @@
 namespace YYiisoft\Factory\Tests\Unit\Resolvers;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Definitions\ClassDefinition;
 use Yiisoft\Factory\Definitions\DefinitionInterface;
+use Yiisoft\Factory\Definitions\InvalidDefinition;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
+use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Resolvers\ClassNameResolver;
 use Yiisoft\Factory\Tests\Support\Car;
 use Yiisoft\Factory\Tests\Support\GearBox;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\ArrayArgument;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\BooleanArgument;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\CallableArgument;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\IntArgument;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\ObjectArgument;
+use Yiisoft\Factory\Tests\Support\HasNoDefaultValue\StringArgument;
 use Yiisoft\Factory\Tests\Support\NullableConcreteDependency;
 use Yiisoft\Factory\Tests\Support\NullableInterfaceDependency;
 use Yiisoft\Factory\Tests\Support\OptionalConcreteDependency;
@@ -89,5 +96,32 @@ class ClassNameResolverTest extends TestCase
         $dependencies = $resolver->resolveConstructor(NullableConcreteDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies[0]->resolve($container));
+    }
+
+    /**
+     * @dataProvider hasNoDefaultValueProvider()
+     * @param string $class
+     * @throws \Yiisoft\Factory\Exceptions\NotInstantiableException
+     */
+    public function testFailResolveArgument(string $class): void
+    {
+        $resolver = new ClassNameResolver();
+        /** @var DefinitionInterface[] $dependencies */
+        $dependencies = $resolver->resolveConstructor($class);
+
+        $this->assertCount(1, $dependencies);
+        $this->assertInstanceOf(InvalidDefinition::class, $dependencies[0]);
+    }
+
+    public function hasNoDefaultValueProvider(): array
+    {
+        return [
+            'array' => [ArrayArgument::class],
+            'callable' => [CallableArgument::class],
+            'int' => [IntArgument::class],
+            'object' => [ObjectArgument::class],
+            'string' => [StringArgument::class],
+            'bool' => [BooleanArgument::class],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

If argument has no default value now resolver will throw exception instead of returning `null` value.
It need when parameter has not-nullable typehint (e.g. `array`, `string` and etc.), because it this case we will get `TypeError` exception