### PR TITLE
Remove unnecessary `ValueDefinition` wrapping

### DIFF
--- a/src/Definitions/ArrayBuilder.php
+++ b/src/Definitions/ArrayBuilder.php
@@ -23,11 +23,7 @@ class ArrayBuilder
             $this->validateParameters($parameters);
 
             foreach ($parameters as $index => $parameter) {
-                if ($parameter instanceof ReferenceInterface || is_array($parameter)) {
-                    $this->injectParameter($dependencies, $index, $parameter);
-                } else {
-                    $this->injectParameter($dependencies, $index, new ValueDefinition($parameter));
-                }
+                $this->injectParameter($dependencies, $index, $parameter);
             }
         }
 


### PR DESCRIPTION
Looks like something obsolete - resolving works fine without it.
Tests pass in both di and factory.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
