### PR TITLE
Fix #30: DynamicReference incompatible with ReferenceInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ with dependencies resolved by a PSR-11 container.
 
 ## General usage
 
+## Unit testing
+
+The package is tested with [PHPUnit](https://phpunit.de/). To run tests:
+
+```php
+./vendor/bin/phpunit
+```
+

--- a/src/Definitions/DynamicReference.php
+++ b/src/Definitions/DynamicReference.php
@@ -6,7 +6,7 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Class DynamicReference allows us to define a dependency to a service not defined in the container.
- * This class implements the array configuration syntax common to Yii
+ * Definition may be defined multiple ways ( @see Normalizer ).
  * For example:
  * ```php
  * [
@@ -17,7 +17,7 @@ use Psr\Container\ContainerInterface;
  *            DynamicReference::to([
  *                '__class' => SomeClass::class,
  *                'someProp' => 15
- *            ]
+ *            ])
  *        ]
  *    ]
  * ]
@@ -32,6 +32,11 @@ class DynamicReference implements ReferenceInterface
         $this->definition = Normalizer::normalize($definition);
     }
 
+    /**
+     * @param mixed $definition
+     * @return DynamicReference
+     * @see Normalizer
+     */
     public static function to($definition): DynamicReference
     {
         return new self($definition);

--- a/src/Definitions/Reference.php
+++ b/src/Definitions/Reference.php
@@ -33,8 +33,15 @@ class Reference implements ReferenceInterface
         return $this->id;
     }
 
-    public static function to(string $id): Reference
+    /**
+     * @param string $id
+     * @return Reference
+     */
+    public static function to($id): Reference
     {
+        if (!\is_string($id)) {
+            throw new \RuntimeException('$id should be string.');
+        }
         return new self($id);
     }
 

--- a/src/Definitions/ReferenceInterface.php
+++ b/src/Definitions/ReferenceInterface.php
@@ -4,5 +4,5 @@ namespace Yiisoft\Factory\Definitions;
 
 interface ReferenceInterface extends DefinitionInterface
 {
-    public static function to(string $id): Reference;
+    public static function to($id): ReferenceInterface;
 }

--- a/tests/Unit/Definitions/DynamicReferenceTest.php
+++ b/tests/Unit/Definitions/DynamicReferenceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Yiisoft\Factory\Tests\Unit\Definitions;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Yiisoft\Di\Container;
+use Yiisoft\Factory\Definitions\DynamicReference;
+use Yiisoft\Factory\Tests\Support\EngineInterface;
+use Yiisoft\Factory\Tests\Support\EngineMarkOne;
+
+class DynamicReferenceTest extends TestCase
+{
+
+    public function createContainer(): ContainerInterface
+    {
+        return new Container([
+            EngineInterface::class => EngineMarkOne::class,
+        ]);
+    }
+
+    public function testString(): void
+    {
+        $ref = DynamicReference::to(EngineInterface::class);
+        $this->assertInstanceOf(EngineMarkOne::class, $ref->resolve($this->createContainer()));
+    }
+
+    public function testClosure(): void
+    {
+        $ref = DynamicReference::to(function (ContainerInterface $container) {
+            return $container->get(EngineInterface::class);
+        });
+        $this->assertInstanceOf(EngineMarkOne::class, $ref->resolve($this->createContainer()));
+    }
+
+    public function testCallable(): void
+    {
+        $ref = DynamicReference::to([static::class, 'callableDefinition']);
+        $this->assertInstanceOf(EngineMarkOne::class, $ref->resolve($this->createContainer()));
+    }
+
+    public static function callableDefinition(ContainerInterface $container)
+    {
+        return $container->get(EngineInterface::class);
+    }
+
+    public function testFullDefinition(): void
+    {
+        $ref = DynamicReference::to([
+            '__class' => EngineMarkOne::class,
+        ]);
+        $this->assertInstanceOf(EngineMarkOne::class, $ref->resolve($this->createContainer()));
+    }
+}

--- a/tests/Unit/Definitions/ReferenceTest.php
+++ b/tests/Unit/Definitions/ReferenceTest.php
@@ -16,4 +16,10 @@ class ReferenceTest extends TestCase
         $ref = Reference::to(EngineInterface::class);
         $this->assertSame(EngineInterface::class, $ref->getId());
     }
+
+    public function testInvalid(): void
+    {
+        $this->expectErrorMessage('$id should be string.');
+        Reference::to(['__class' => EngineInterface::class]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #30 

In ReferenceInterface remove type of argument and change returned type to interface.
Add tests for DynamicReference.