### PR TITLE
Extend `CallableDefinition` to allow more complex definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "league/container": "^3.2",
         "phan/phan": "^3.0",
         "phpunit/phpunit": "^9.3",
+        "yiisoft/injector": "^1.0@dev",
         "yiisoft/di": "^3.0@dev"
+    },
+    "suggest": {
+        "yiisoft/injector": "^1.0@dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Definitions/CallableDefinition.php
+++ b/src/Definitions/CallableDefinition.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Yiisoft\Factory\Definitions;
 
 use Psr\Container\ContainerInterface;
+use Yiisoft\Injector\Injector;
 
 class CallableDefinition implements DefinitionInterface
 {
     private $method;
 
-    public function __construct(callable $method)
+    public function __construct($method)
     {
         $this->method = $method;
     }
@@ -18,6 +19,10 @@ class CallableDefinition implements DefinitionInterface
     public function resolve(ContainerInterface $container)
     {
         $callback = $this->method;
+        if ($container->has(Injector::class)) {
+            return $container->get(Injector::class)->invoke($callback);
+        }
+
         return $callback($container);
     }
 }

--- a/src/Definitions/Normalizer.php
+++ b/src/Definitions/Normalizer.php
@@ -51,7 +51,7 @@ class Normalizer
      */
     public static function normalize($config, string $id = null, array $params = []): DefinitionInterface
     {
-        if ($config instanceof ReferenceInterface) {
+        if ($config instanceof DefinitionInterface) {
             return $config;
         }
 

--- a/tests/Unit/AbstractFactoryTest.php
+++ b/tests/Unit/AbstractFactoryTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Factory\Tests\Unit;
 
-use Assert\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use League\Container\Container;
 use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Tests\Support\Car;
 use Yiisoft\Factory\Tests\Support\EngineInterface;

--- a/tests/Unit/FactoryOverYiisoftTest.php
+++ b/tests/Unit/FactoryOverYiisoftTest.php
@@ -22,11 +22,7 @@ class FactoryOverYiisoftTest extends AbstractFactoryTest
 
     public function testCreateFactory(): void
     {
-        $container = $this->createContainer([
-            ContainerInterface::class => static function (ContainerInterface $container) {
-                return $container;
-            },
-        ]);
+        $container = $this->createContainer();
         $factory = new Factory($container, [
             'factory' => [
                 '__class' => Factory::class,
@@ -46,11 +42,7 @@ class FactoryOverYiisoftTest extends AbstractFactoryTest
 
     public function testCreateFactoryImmutable(): void
     {
-        $container = $this->createContainer([
-            ContainerInterface::class => static function (ContainerInterface $container) {
-                return $container;
-            },
-        ]);
+        $container = $this->createContainer();
         $factory = new Factory($container, [
             'factory' => [
                 '__class' => Immutable::class,


### PR DESCRIPTION
- used injector to resolve callbacks with any number of arguments resolved automatically
- added Reference::toCall($object, $method, $args)

This PR enables complex call definitions like:

```php
$definitions = [
    'callback' => function (FactoryInterface $factory, ProviderInterface $provider) {
        $provision = $provider->getProvision();
        return $factory->create('option', $provision);
    },
    'complex call with toCall' => Reference::toCall(SomeFactory::class, 'create', ['more' => 'arguments']),
    'complex call with closure' => fn (SomeFactory $factory) => $factory->create('arguments'),
    'static call with closure' => fn () => SomeFactory::create('arguments'),
]
```

This PR requires corresponding PR in yiisoft/di to pass tests.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/di/issues/148
