### PR TITLE
Rename resolver to extractor

### DIFF
--- a/src/Definitions/ArrayBuilder.php
+++ b/src/Definitions/ArrayBuilder.php
@@ -6,14 +6,14 @@ namespace Yiisoft\Factory\Definitions;
 
 use Psr\Container\ContainerInterface;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
-use Yiisoft\Factory\Resolvers\ClassNameResolver;
+use Yiisoft\Factory\Extractors\DefinitionExtractor;
 
 /**
  * Builds object by ArrayDefinition.
  */
 class ArrayBuilder
 {
-    private static ?ClassNameResolver $resolver = null;
+    private static ?DefinitionExtractor $extractor = null;
     private static array $dependencies = [];
 
     public function build(ContainerInterface $container, ArrayDefinition $definition)
@@ -125,20 +125,20 @@ class ArrayBuilder
     private function getDependencies(string $class): array
     {
         if (!isset(self::$dependencies[$class])) {
-            self::$dependencies[$class] = $this->getResolver()->resolveConstructor($class);
+            self::$dependencies[$class] = $this->getExtractor()->fromClassName($class);
         }
 
         return self::$dependencies[$class];
     }
 
-    private function getResolver(): ClassNameResolver
+    private function getExtractor(): DefinitionExtractor
     {
-        if (static::$resolver === null) {
-            // For now use hard coded resolver.
-            static::$resolver = new ClassNameResolver();
+        if (static::$extractor === null) {
+            // For now use hard coded extractor.
+            static::$extractor = new DefinitionExtractor();
         }
 
-        return static::$resolver;
+        return static::$extractor;
     }
 
     /**

--- a/src/Extractors/ExtractorInterface.php
+++ b/src/Extractors/ExtractorInterface.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Factory\Resolvers;
+namespace Yiisoft\Factory\Extractors;
 
 use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
 
 /**
- * Interface DependencyResolverInterface
+ * Interface ExtractorInterface
  */
-interface DependencyResolverInterface
+interface ExtractorInterface
 {
     /**
      * @param string $class
      * @return DefinitionInterface[] An array of direct dependencies of $class.
      * @throws NotInstantiableException If the class is not instantiable this MUST throw a NotInstantiableException
      */
-    public function resolveConstructor(string $class): array;
+    public function fromClassName(string $class): array;
 
     /**
      * @param callable $callable
      * @return DefinitionInterface[] An array of direct dependencies of the callable.
      */
-    public function resolveCallable(callable $callable): array;
+    public function fromCallable(callable $callable): array;
 }

--- a/tests/Unit/Resolvers/ClassNameResolverTest.php
+++ b/tests/Unit/Resolvers/ClassNameResolverTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Definitions\ClassDefinition;
 use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
-use Yiisoft\Factory\Resolvers\ClassNameResolver;
+use Yiisoft\Factory\Extractors\DefinitionExtractor;
 use Yiisoft\Factory\Tests\Support\Car;
 use Yiisoft\Factory\Tests\Support\GearBox;
 use Yiisoft\Factory\Tests\Support\NullableConcreteDependency;
@@ -17,15 +17,15 @@ use Yiisoft\Factory\Tests\Support\NullableInterfaceDependency;
 use Yiisoft\Factory\Tests\Support\OptionalConcreteDependency;
 use Yiisoft\Factory\Tests\Support\OptionalInterfaceDependency;
 
-class ClassNameResolverTest extends TestCase
+class DefinitionExtractorTest extends TestCase
 {
     public function testResolveConstructor(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
 
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(\DateTime::class);
+        $dependencies = $resolver->fromClassName(\DateTime::class);
 
 
         $this->assertCount(2, $dependencies);
@@ -43,10 +43,10 @@ class ClassNameResolverTest extends TestCase
 
     public function testResolveCarConstructor(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(Car::class);
+        $dependencies = $resolver->fromClassName(Car::class);
 
         $this->assertCount(1, $dependencies);
         $this->assertInstanceOf(ClassDefinition::class, $dependencies['engine']);
@@ -56,48 +56,48 @@ class ClassNameResolverTest extends TestCase
 
     public function testResolveGearBoxConstructor(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(GearBox::class);
+        $dependencies = $resolver->fromClassName(GearBox::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(5, $dependencies['maxGear']->resolve($container));
     }
 
     public function testOptionalInterfaceDependency(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(OptionalInterfaceDependency::class);
+        $dependencies = $resolver->fromClassName(OptionalInterfaceDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies['engine']->resolve($container));
     }
     public function testNullableInterfaceDependency(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(NullableInterfaceDependency::class);
+        $dependencies = $resolver->fromClassName(NullableInterfaceDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies['engine']->resolve($container));
     }
 
     public function testOptionalConcreteDependency(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(OptionalConcreteDependency::class);
+        $dependencies = $resolver->fromClassName(OptionalConcreteDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies['car']->resolve($container));
     }
     public function testNullableConcreteDependency(): void
     {
-        $resolver = new ClassNameResolver();
+        $resolver = new DefinitionExtractor();
         $container = new Factory();
         /** @var DefinitionInterface[] $dependencies */
-        $dependencies = $resolver->resolveConstructor(NullableConcreteDependency::class);
+        $dependencies = $resolver->fromClassName(NullableConcreteDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies['car']->resolve($container));
     }


### PR DESCRIPTION
`resolve` name is used for `Definition` to instance resolving

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
