### PR TITLE
Allow any definition in constructor arguments

### DIFF
--- a/src/Definitions/ArrayBuilder.php
+++ b/src/Definitions/ArrayBuilder.php
@@ -26,7 +26,7 @@ class ArrayBuilder
             $this->validateParameters($parameters);
 
             foreach ($parameters as $index => $parameter) {
-                if ($parameter instanceof ReferenceInterface || is_array($parameter)) {
+                if ($parameter instanceof DefinitionInterface || is_array($parameter)) {
                     $this->injectParameter($dependencies, $index, $parameter);
                 } else {
                     $this->injectParameter($dependencies, $index, new ValueDefinition($parameter));

--- a/src/Definitions/ArrayBuilder.php
+++ b/src/Definitions/ArrayBuilder.php
@@ -26,11 +26,7 @@ class ArrayBuilder
             $this->validateParameters($parameters);
 
             foreach ($parameters as $index => $parameter) {
-                if ($parameter instanceof DefinitionInterface || is_array($parameter)) {
-                    $this->injectParameter($dependencies, $index, $parameter);
-                } else {
-                    $this->injectParameter($dependencies, $index, new ValueDefinition($parameter));
-                }
+                $this->injectParameter($dependencies, $index, DefinitionResolver::ensureResolvable($parameter));
             }
         }
 

--- a/src/Definitions/DefinitionResolver.php
+++ b/src/Definitions/DefinitionResolver.php
@@ -40,4 +40,16 @@ class DefinitionResolver
 
         return $definition;
     }
+
+    public static function ensureResolvable($value)
+    {
+        if ($value instanceof DefinitionInterface || is_array($value)) {
+            return $value;
+        }
+        if (is_callable($value)) {
+            return new CallableDefinition($value);
+        }
+
+        return new ValueDefinition($value);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

This allows use any definitions for constructor arguments.

E.g. more granular closure like this:

```php
View::class => [
    '__construct()' => [
      'basePath' => fn(Aliases $aliases) => $aliases->get('@view'),
    ],
]
```

instead of:

```php
View::class => function (Aliases $aliases, EventDispatcherInterface $eventDispatcher, Theme $theme, LoggerInterface $logger) {
    return new View($aliases->get('@view'), $theme, $eventDispatcher, $logger);
}
```

Also this changes allow to keep closure as is with `ValueDefinition`:

```php
$engine = new MyEngine();
$closure = fn() => $engine;
$config = [
    MyCar::class => [
        '__construct' => [
            'mainEngine' => $closure,
            'closureArgument' => new ValueDefinition($closure),
        ],
    ],
    'engine' => $closure,
    'closure' => new ValueDefinition($closure),
];
```
