### PR TITLE
Fix #18: remove `get` method and `ContainerInterface` from factory

### DIFF
--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Factory;
 
-use Psr\Container\ContainerInterface;
 use Yiisoft\Factory\Exceptions\InvalidConfigException;
 
 /**
@@ -13,7 +12,7 @@ use Yiisoft\Factory\Exceptions\InvalidConfigException;
  * but will fall back to manual instantiation
  * if the container cannot provide a required dependency.
  */
-interface FactoryInterface extends ContainerInterface
+interface FactoryInterface
 {
     /**
      * Creates a new object using the given configuration and constructor arguments.
@@ -59,4 +58,17 @@ interface FactoryInterface extends ContainerInterface
      * @throws InvalidConfigException if the configuration is invalid.
      */
     public function create($config, array $params = []);
+
+    /**
+     * Returns true if the factory has definition for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id class name, interface name or alias name
+     *
+     * @return bool
+     */
+    public function has($id);
 }

--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Factory;
+
+use Psr\Container\ContainerInterface;
+use Yiisoft\Factory\Definitions\ArrayDefinition;
+use Yiisoft\Factory\Definitions\DefinitionInterface;
+
+class Wrapper implements ContainerInterface
+{
+    private Factory $factory;
+    private ?ContainerInterface $container;
+
+    public function __construct(Factory $factory, ContainerInterface $container = null)
+    {
+        $this->factory = $factory;
+        $this->container = $container;
+    }
+
+    public function get($id)
+    {
+        return $this->resolve($this->factory->getDefinition($id));
+    }
+
+    public function has($id): bool
+    {
+        return $this->factory->has($id);
+    }
+
+    public function resolve(DefinitionInterface $definition)
+    {
+        $container = $definition instanceof ArrayDefinition ? $this->container : $this;
+
+        return $definition->resolve($container ?? $this);
+    }
+}

--- a/tests/Unit/AbstractFactoryTest.php
+++ b/tests/Unit/AbstractFactoryTest.php
@@ -59,16 +59,21 @@ abstract class AbstractFactoryTest extends TestCase
     }
 
     /**
-     * Factory should always return new instance even if an object is set to it.
-     * In this case it is being cloned.
+     * When defintion is given as a concrete object then factory returns same instance.
+     * To get new instance every time other defintion (e.g. closure) must be used.
      */
-    public function testObjectIsCloned(): void
+    public function testSameInstance(): void
     {
         $factory = new Factory($this->createContainer(), [
-            'engine' => new EngineMarkOne(),
+            'concrete' => new EngineMarkOne(),
+            'variable' => fn () => new EngineMarkOne(),
         ]);
-        $one = $factory->create('engine');
-        $two = $factory->create('engine');
+        $one = $factory->create('concrete');
+        $two = $factory->create('concrete');
+        $this->assertSame($one, $two);
+        $this->assertInstanceOf(EngineMarkOne::class, $two);
+        $one = $factory->create('variable');
+        $two = $factory->create('variable');
         $this->assertNotSame($one, $two);
         $this->assertInstanceOf(EngineMarkOne::class, $two);
     }
@@ -130,8 +135,8 @@ abstract class AbstractFactoryTest extends TestCase
         $factory = new Factory($this->createContainer(), [
             'engine' => EngineMarkOne::class,
         ]);
-        $one = $factory->get('engine');
-        $two = $factory->get('engine');
+        $one = $factory->create('engine');
+        $two = $factory->create('engine');
         $this->assertNotSame($one, $two);
         $this->assertInstanceOf(EngineMarkOne::class, $one);
         $this->assertInstanceOf(EngineMarkOne::class, $two);
@@ -141,8 +146,8 @@ abstract class AbstractFactoryTest extends TestCase
     {
         $factory = new Factory($this->createContainer());
         $factory->set(EngineMarkOne::class, EngineMarkOne::class);
-        $one = $factory->get(EngineMarkOne::class);
-        $two = $factory->get(EngineMarkOne::class);
+        $one = $factory->create(EngineMarkOne::class);
+        $two = $factory->create(EngineMarkOne::class);
         $this->assertNotSame($one, $two);
         $this->assertInstanceOf(EngineMarkOne::class, $one);
         $this->assertInstanceOf(EngineMarkOne::class, $two);
@@ -154,8 +159,8 @@ abstract class AbstractFactoryTest extends TestCase
     public function testCreateWithParams(): void
     {
         $factory = new Factory($this->createContainer());
-        $one = $factory->create(Car::class, [$factory->get(EngineMarkOne::class)]);
-        $two = $factory->create(Car::class, [$factory->get(EngineMarkTwo::class)]);
+        $one = $factory->create(Car::class, [$factory->create(EngineMarkOne::class)]);
+        $two = $factory->create(Car::class, [$factory->create(EngineMarkTwo::class)]);
         $this->assertNotSame($one, $two);
         $this->assertInstanceOf(Car::class, $one);
         $this->assertInstanceOf(Car::class, $two);
@@ -166,8 +171,8 @@ abstract class AbstractFactoryTest extends TestCase
     public function testCreateWithNamedParams(): void
     {
         $factory = new Factory($this->createContainer());
-        $one = $factory->create(Car::class, ['engine' => $factory->get(EngineMarkOne::class)]);
-        $two = $factory->create(Car::class, ['engine' => $factory->get(EngineMarkTwo::class)]);
+        $one = $factory->create(Car::class, ['engine' => $factory->create(EngineMarkOne::class)]);
+        $two = $factory->create(Car::class, ['engine' => $factory->create(EngineMarkTwo::class)]);
         $this->assertNotSame($one, $two);
         $this->assertInstanceOf(Car::class, $one);
         $this->assertInstanceOf(Car::class, $two);

--- a/tests/Unit/Extractors/DefinitionExtractorTest.php
+++ b/tests/Unit/Extractors/DefinitionExtractorTest.php
@@ -5,24 +5,26 @@ declare(strict_types=1);
 namespace YYiisoft\Factory\Tests\Unit\Resolvers;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Factory\Factory;
+use Psr\Container\ContainerInterface;
 use Yiisoft\Factory\Definitions\ClassDefinition;
 use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
 use Yiisoft\Factory\Extractors\DefinitionExtractor;
+use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Tests\Support\Car;
 use Yiisoft\Factory\Tests\Support\GearBox;
 use Yiisoft\Factory\Tests\Support\NullableConcreteDependency;
 use Yiisoft\Factory\Tests\Support\NullableInterfaceDependency;
 use Yiisoft\Factory\Tests\Support\OptionalConcreteDependency;
 use Yiisoft\Factory\Tests\Support\OptionalInterfaceDependency;
+use Yiisoft\Factory\Wrapper;
 
 class DefinitionExtractorTest extends TestCase
 {
     public function testResolveConstructor(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
 
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(\DateTime::class);
@@ -44,7 +46,7 @@ class DefinitionExtractorTest extends TestCase
     public function testResolveCarConstructor(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(Car::class);
 
@@ -57,7 +59,7 @@ class DefinitionExtractorTest extends TestCase
     public function testResolveGearBoxConstructor(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(GearBox::class);
         $this->assertCount(1, $dependencies);
@@ -67,7 +69,7 @@ class DefinitionExtractorTest extends TestCase
     public function testOptionalInterfaceDependency(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(OptionalInterfaceDependency::class);
         $this->assertCount(1, $dependencies);
@@ -76,7 +78,7 @@ class DefinitionExtractorTest extends TestCase
     public function testNullableInterfaceDependency(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(NullableInterfaceDependency::class);
         $this->assertCount(1, $dependencies);
@@ -86,7 +88,7 @@ class DefinitionExtractorTest extends TestCase
     public function testOptionalConcreteDependency(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(OptionalConcreteDependency::class);
         $this->assertCount(1, $dependencies);
@@ -95,10 +97,15 @@ class DefinitionExtractorTest extends TestCase
     public function testNullableConcreteDependency(): void
     {
         $resolver = new DefinitionExtractor();
-        $container = new Factory();
+        $container = $this->getContainer();
         /** @var DefinitionInterface[] $dependencies */
         $dependencies = $resolver->fromClassName(NullableConcreteDependency::class);
         $this->assertCount(1, $dependencies);
         $this->assertEquals(null, $dependencies['car']->resolve($container));
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        return new Wrapper(new Factory());
     }
 }


### PR DESCRIPTION
Added `Wrapper` to satisfy `ContainerInterface` required in `DefinitionInterface`.

Also note slightly changed behavior when given a concrete object as definition.
See `AbstractFactoryTest::testSameInstance`.
https://github.com/yiisoft/factory/pull/44/files#diff-9f828ae21b0b845a57256f8f12ded08eL65-R79

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #18
