### PR TITLE
Fix constructor parameters injecting

### DIFF
--- a/src/Definitions/ArrayBuilder.php
+++ b/src/Definitions/ArrayBuilder.php
@@ -53,12 +53,6 @@ class ArrayBuilder
                     $dependencies[$index] = DefinitionResolver::ensureResolvable($value);
                 }
             }
-        } elseif (!$isInteger) {
-            foreach (array_keys($parameters) as $key) {
-                if (!isset($dependencies[$key])) {
-                    throw new InvalidConfigException('Unknown named parameter $' . $key);
-                }
-            }
         }
     }
 

--- a/src/Definitions/ParameterDefinition.php
+++ b/src/Definitions/ParameterDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Factory\Definitions;
+
+use ReflectionParameter;
+
+class ParameterDefinition extends ValueDefinition
+{
+    private ReflectionParameter $parameter;
+
+    public function __construct(ReflectionParameter $parameter, $value, string $type = null)
+    {
+        $this->parameter = $parameter;
+        parent::__construct($value, $type);
+    }
+
+    public function getParameter(): ReflectionParameter
+    {
+        return $this->parameter;
+    }
+}

--- a/src/Extractors/DefinitionExtractor.php
+++ b/src/Extractors/DefinitionExtractor.php
@@ -6,8 +6,7 @@ namespace Yiisoft\Factory\Extractors;
 
 use Yiisoft\Factory\Definitions\DefinitionInterface;
 use Yiisoft\Factory\Definitions\ClassDefinition;
-use Yiisoft\Factory\Definitions\InvalidDefinition;
-use Yiisoft\Factory\Definitions\ValueDefinition;
+use Yiisoft\Factory\Definitions\ParameterDefinition;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
 
 /**
@@ -47,17 +46,14 @@ class DefinitionExtractor implements ExtractorInterface
         $type = $parameter->getType();
         $hasDefault = $parameter->isOptional() || $parameter->isDefaultValueAvailable() || (isset($type) && $type->allowsNull());
 
-        if (!$hasDefault && $type === null) {
-            return new InvalidDefinition();
-        }
-
         // Our parameter has a class type hint
         if ($type !== null && !$type->isBuiltin()) {
             return new ClassDefinition($type->getName(), $type->allowsNull());
         }
 
         // Our parameter does not have a class type hint and either has a default value or is nullable.
-        return new ValueDefinition(
+        return new ParameterDefinition(
+            $parameter,
             $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
             $type !== null ? $type->getName() : null
         );

--- a/tests/Unit/AbstractFactoryTest.php
+++ b/tests/Unit/AbstractFactoryTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Factory\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Yiisoft\Factory\Exceptions\InvalidConfigException;
 use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Definitions\Reference;
 use Yiisoft\Factory\Tests\Support\Car;
@@ -179,7 +180,7 @@ abstract class AbstractFactoryTest extends TestCase
     {
         $factory = new Factory($this->createContainer());
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidConfigException::class);
         $factory->create(TwoParametersDependency::class, ['firstParam' => 'param1', 1 => 'param2']);
     }
 

--- a/tests/Unit/FactoryOverLeagueTest.php
+++ b/tests/Unit/FactoryOverLeagueTest.php
@@ -36,7 +36,7 @@ class FactoryOverLeagueTest extends AbstractFactoryTest
             'factory' => [
                 '__class' => Factory::class,
                 '__construct()' => [
-                    'parent'        => Reference::to(ContainerInterface::class),
+                    'container'     => Reference::to(ContainerInterface::class),
                     'definitions'   => [],
                 ],
             ],

--- a/tests/Unit/FactoryOverYiisoftTest.php
+++ b/tests/Unit/FactoryOverYiisoftTest.php
@@ -27,7 +27,7 @@ class FactoryOverYiisoftTest extends AbstractFactoryTest
             'factory' => [
                 '__class' => Factory::class,
                 '__construct()' => [
-                    'parent'        => Reference::to(ContainerInterface::class),
+                    'container'     => Reference::to(ContainerInterface::class),
                     'definitions'   => [],
                 ],
             ],


### PR DESCRIPTION
- constructor with default values is called properly
- skip excessive parameters
- pass all arguments if parameter is variadic

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/di/issues/157, https://github.com/yiisoft/di/pull/172, https://github.com/yiisoft/di/pull/173
