### PR TITLE
Allow array based callable definition to non-static method

### DIFF
--- a/src/Definitions/CallableDefinition.php
+++ b/src/Definitions/CallableDefinition.php
@@ -5,19 +5,34 @@ declare(strict_types=1);
 namespace Yiisoft\Factory\Definitions;
 
 use Psr\Container\ContainerInterface;
+use ReflectionMethod;
 use Yiisoft\Injector\Injector;
 
 class CallableDefinition implements DefinitionInterface
 {
     private $method;
 
-    public function __construct(callable $method)
+    public function __construct($method)
     {
         $this->method = $method;
     }
 
     public function resolve(ContainerInterface $container)
     {
-        return $container->get(Injector::class)->invoke($this->method);
+        $callable = $this->prepareCallable($this->method, $container);
+
+        return $container->get(Injector::class)->invoke($callable);
+    }
+
+    private function prepareCallable($callable, ContainerInterface $container): callable
+    {
+        if (is_array($callable) && !is_object($callable[0])) {
+            $reflection = new ReflectionMethod($callable[0], $callable[1]);
+            if (!$reflection->isStatic()) {
+                $callable[0] = $container->get($callable[0]);
+            }
+        }
+
+        return $callable;
     }
 }

--- a/src/Definitions/Normalizer.php
+++ b/src/Definitions/Normalizer.php
@@ -62,7 +62,7 @@ class Normalizer
             return Reference::to($definition);
         }
 
-        if (\is_callable($definition)) {
+        if (\is_callable($definition, true)) {
             return new CallableDefinition($definition);
         }
 


### PR DESCRIPTION
E.g. `'engine' => [EngineFactory::class, 'createMethod']`
Both EngineFactory constructor and `createMethod` dependencies
will be resolved with container.
Tests in `yiisoft/di`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
