### PR TITLE
Remove `ArrayDefinition::mergeConstructorArguments()`, mark `Factory::getDefinition()` as private, more tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,9 @@
         "irc": "irc://irc.freenode.net/yii",
         "source": "https://github.com/yiisoft/factory"
     },
-    "minimum-stability": "dev",
     "require": {
         "php": "^7.4|^8.0",
-        "psr/container": "^1.0.0",
+        "psr/container": "^1.0|^2.0",
         "yiisoft/injector": "^1.0"
     },
     "require-dev": {

--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -105,11 +105,6 @@ class ArrayDefinition implements DefinitionInterface
         return $this->constructorArguments;
     }
 
-    public function mergeConstructorArguments(array $arguments): void
-    {
-        $this->constructorArguments = $this->mergeArguments($this->constructorArguments, $arguments);
-    }
-
     /**
      * @psalm-return array<string, MethodOrPropertyItem>
      */

--- a/src/Definition/ArrayDefinitionBuilder.php
+++ b/src/Definition/ArrayDefinitionBuilder.php
@@ -109,6 +109,9 @@ final class ArrayDefinitionBuilder
         /** @psalm-var array<string, DefinitionInterface> $dependencies */
     }
 
+    /**
+     * @throws InvalidConfigException
+     */
     private function isIntegerIndexed(array $arguments): bool
     {
         $hasStringIndex = false;

--- a/src/Definition/Normalizer.php
+++ b/src/Definition/Normalizer.php
@@ -97,6 +97,6 @@ class Normalizer
             return new ValueDefinition($definition);
         }
 
-        throw new InvalidConfigException('Invalid definition:' . var_export($definition, true));
+        throw new InvalidConfigException('Invalid definition: ' . var_export($definition, true));
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -109,7 +109,7 @@ class Factory implements FactoryInterface
     /**
      * @throws InvalidConfigException
      */
-    public function getDefinition(string $id): DefinitionInterface
+    private function getDefinition(string $id): DefinitionInterface
     {
         if (!isset($this->definitionInstances[$id])) {
             if (isset($this->definitions[$id])) {

--- a/tests/Support/Cube.php
+++ b/tests/Support/Cube.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Factory\Tests\Support;
+
+final class Cube
+{
+    private ColorInterface $color;
+
+    public function __construct(ColorInterface $color)
+    {
+        $this->color = $color;
+    }
+
+    public function getColor(): ColorInterface
+    {
+        return $this->color;
+    }
+}

--- a/tests/Support/Firefighter.php
+++ b/tests/Support/Firefighter.php
@@ -18,4 +18,3 @@ final class Firefighter
         return $this->name;
     }
 }
-

--- a/tests/Support/Firefighter.php
+++ b/tests/Support/Firefighter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Factory\Tests\Support;
+
+final class Firefighter
+{
+    private ?string $name;
+
+    public function __construct(?string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}
+

--- a/tests/Unit/Definition/DefinitionValidatorTest.php
+++ b/tests/Unit/Definition/DefinitionValidatorTest.php
@@ -84,21 +84,21 @@ final class DefinitionValidatorTest extends TestCase
     public function dataErrorOnPropertyOrMethodTypo(): array
     {
         return [
-            ['dev', true, 'Invalid definition: key "dev" is not allowed. Did you mean "dev()" or "$dev"?'],
-            ['setId', [42], 'Invalid definition: key "setId" is not allowed. Did you mean "setId()" or "$setId"?'],
-            ['()test', [42], 'Invalid definition: key "()test" is not allowed. Did you mean "test()" or "$test"?'],
-            ['var$', true, 'Invalid definition: key "var$" is not allowed. Did you mean "var()" or "$var"?'],
-            ['100$', true, 'Invalid definition: key "100$" is not allowed.'],
+            ['dev', true, '~^Invalid definition: key "dev" is not allowed\. Did you mean "dev\(\)" or "\$dev"\?$~'],
+            ['setId', [42], '~^Invalid definition: key "setId" is not allowed\. Did you mean "setId\(\)" or "\$setId"\?$~'],
+            ['()test', [42], '~^Invalid definition: key "\(\)test" is not allowed\. Did you mean "test\(\)" or "\$test"\?$~'],
+            ['var$', true, '~^Invalid definition: key "var\$" is not allowed\. Did you mean "var\(\)" or "\$var"\?$~'],
+            ['100$', true, '~^Invalid definition: key "100\$" is not allowed\.$~'],
         ];
     }
 
     /**
      * @dataProvider dataErrorOnPropertyOrMethodTypo
      */
-    public function testErrorOnPropertyOrMethodTypo(string $key, $value, string $message): void
+    public function testErrorOnPropertyOrMethodTypo(string $key, $value, string $regExp): void
     {
         $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessage($message);
+        $this->expectExceptionMessageMatches($regExp);
         DefinitionValidator::validate([
             'class' => Phone::class,
             $key => $value,

--- a/tests/Unit/Definition/DefinitionValidatorTest.php
+++ b/tests/Unit/Definition/DefinitionValidatorTest.php
@@ -88,7 +88,9 @@ final class DefinitionValidatorTest extends TestCase
             ['setId', [42], '~^Invalid definition: key "setId" is not allowed\. Did you mean "setId\(\)" or "\$setId"\?$~'],
             ['()test', [42], '~^Invalid definition: key "\(\)test" is not allowed\. Did you mean "test\(\)" or "\$test"\?$~'],
             ['var$', true, '~^Invalid definition: key "var\$" is not allowed\. Did you mean "var\(\)" or "\$var"\?$~'],
+            [' var$', true, '~^Invalid definition: key " var\$" is not allowed\. Did you mean "var\(\)" or "\$var"\?$~'],
             ['100$', true, '~^Invalid definition: key "100\$" is not allowed\.$~'],
+            ['test-тест', true, '~^Invalid definition: key "test-тест" is not allowed\.$~'],
         ];
     }
 
@@ -101,6 +103,9 @@ final class DefinitionValidatorTest extends TestCase
         $this->expectExceptionMessageMatches($regExp);
         DefinitionValidator::validate([
             'class' => Phone::class,
+            '__construct()' => ['name' => 'hello'],
+            '$dev' => true,
+            'setId()' => [24],
             $key => $value,
         ]);
     }

--- a/tests/Unit/Definition/ValueDefinitionTest.php
+++ b/tests/Unit/Definition/ValueDefinitionTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Factory\Tests\Unit\Definition;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Yiisoft\Factory\Definition\ValueDefinition;
+use Yiisoft\Factory\Factory;
+use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class ValueDefinitionTest extends TestCase
 {
@@ -14,5 +17,25 @@ final class ValueDefinitionTest extends TestCase
         $definition = new ValueDefinition(42, 'integer');
 
         $this->assertSame('integer', $definition->getType());
+    }
+
+    public function testDoNotCloneObjectFromContainer(): void
+    {
+        $object = new stdClass();
+
+        $definition = new ValueDefinition($object, 'object');
+        $value = $definition->resolve(new SimpleContainer());
+
+        $this->assertSame($object, $value);
+    }
+
+    public function testCloneObjectFromFactory(): void
+    {
+        $object = new stdClass();
+
+        $definition = new ValueDefinition($object, 'object');
+        $value = $definition->resolve(new Factory());
+
+        $this->assertNotSame($object, $value);
     }
 }

--- a/tests/Unit/Exception/NotInstantiableExceptionTest.php
+++ b/tests/Unit/Exception/NotInstantiableExceptionTest.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace Yiisoft\Factory\Tests\Unit\Exception;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 
 final class NotInstantiableExceptionTest extends TestCase
 {
-    public function testWithoutMessage(): void
+    public function testDefaultArguments(): void
     {
         $exception = new NotInstantiableException(stdClass::class);
 
+        $this->assertSame(0, $exception->getCode());
         $this->assertSame('Can not instantiate stdClass.', $exception->getMessage());
+        $this->assertNull($exception->getPrevious());
     }
 
     public function testWithMessage(): void
@@ -22,5 +25,20 @@ final class NotInstantiableExceptionTest extends TestCase
         $exception = new NotInstantiableException(stdClass::class, 'Test message.');
 
         $this->assertSame('Test message.', $exception->getMessage());
+    }
+
+    public function testWithCode(): void
+    {
+        $exception = new NotInstantiableException(stdClass::class, null, 99);
+
+        $this->assertSame(99, $exception->getCode());
+    }
+
+    public function testWithPreviousException(): void
+    {
+        $previousException = new LogicException();
+        $exception = new NotInstantiableException(stdClass::class, null, 0, $previousException);
+
+        $this->assertSame($previousException, $exception->getPrevious());
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -547,6 +547,17 @@ final class FactoryTest extends TestCase
         ]);
     }
 
+    public function testCreateWithInvalidDefinitionWithValidation(): void
+    {
+        $factory = new Factory();
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Invalid definition: invalid key in array definition. Allow only string keys, got 0.'
+        );
+        $factory->create([stdClass::class]);
+    }
+
     public function testCreateWithInvalidDefinitionWithoutValidation(): void
     {
         $factory = new Factory(null, [], false);

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -17,6 +17,7 @@ use Yiisoft\Factory\Tests\Support\Car;
 use Yiisoft\Factory\Tests\Support\EngineInterface;
 use Yiisoft\Factory\Tests\Support\EngineMarkOne;
 use Yiisoft\Factory\Tests\Support\EngineMarkTwo;
+use Yiisoft\Factory\Tests\Support\GearBox;
 use Yiisoft\Factory\Tests\Support\Immutable;
 use Yiisoft\Factory\Tests\Support\Phone;
 use Yiisoft\Factory\Tests\Support\Recorder;
@@ -504,5 +505,18 @@ final class FactoryTest extends TestCase
                 new ValueDefinition(new EngineMarkTwo(), 'object'),
             ],
         ]);
+    }
+
+    public function testSetMultiple(): void
+    {
+        $factory = new Factory();
+
+        $factory->setMultiple([
+            'object1' => [$this, 'createStdClass'],
+            'object2' => GearBox::class,
+        ]);
+
+        $this->assertInstanceOf(stdClass::class, $factory->create('object1'));
+        $this->assertInstanceOf(GearBox::class, $factory->create('object2'));
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -519,4 +519,12 @@ final class FactoryTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $factory->create('object1'));
         $this->assertInstanceOf(GearBox::class, $factory->create('object2'));
     }
+
+    public function testSetInvalidDefinition(): void
+    {
+        $factory = new Factory();
+
+        $this->expectException(InvalidConfigException::class);
+        $factory->set('test', 42);
+    }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -14,6 +14,7 @@ use Yiisoft\Factory\Exception\InvalidConfigException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Tests\Support\Car;
+use Yiisoft\Factory\Tests\Support\Firefighter;
 use Yiisoft\Factory\Tests\Support\ColorPink;
 use Yiisoft\Factory\Tests\Support\Cube;
 use Yiisoft\Factory\Tests\Support\EngineInterface;
@@ -552,5 +553,14 @@ final class FactoryTest extends TestCase
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Invalid definition: 42');
         $factory->create(42);
+    }
+
+    public function testCreateObjectWithNullableStringConstructorArgument(): void
+    {
+        $factory = new Factory();
+
+        $object = $factory->create(Firefighter::class);
+
+        $this->assertNull($object->getName());
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -545,4 +545,13 @@ final class FactoryTest extends TestCase
             '__construct()' => [ArrayDefinition::fromConfig(['class' => ColorPink::class])]
         ]);
     }
+
+    public function testCreateWithInvalidDefinitionWithoutValidation(): void
+    {
+        $factory = new Factory(null, [], false);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Invalid definition: 42');
+        $factory->create(42);
+    }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -14,6 +14,9 @@ use Yiisoft\Factory\Exception\InvalidConfigException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Tests\Support\Car;
+use Yiisoft\Factory\Tests\Support\ColorPink;
+use Yiisoft\Factory\Tests\Support\ConstructorWithoutTypeHint;
+use Yiisoft\Factory\Tests\Support\Cube;
 use Yiisoft\Factory\Tests\Support\EngineInterface;
 use Yiisoft\Factory\Tests\Support\EngineMarkOne;
 use Yiisoft\Factory\Tests\Support\EngineMarkTwo;
@@ -526,5 +529,20 @@ final class FactoryTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $factory->set('test', 42);
+    }
+
+    public function testDefinitionAsConstructorArgument(): void
+    {
+        $factory = new Factory();
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessageMatches(
+            '~^Only references are allowed in parameters, a definition object was provided: ' .
+            'Yiisoft\\\\Factory\\\\Definition\\\\ArrayDefinition::~'
+        );
+        $factory->create([
+            'class' => Cube::class,
+            '__construct()' => [ArrayDefinition::fromConfig(['class' => ColorPink::class])]
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

- Remove unused method `ArrayDefinition::mergeConstructorArguments()`.
- Mark method `Factory::getDefinition()` as private.
- Minor improve phpdoc.
- Minor improve exception message in definition normalizer.
- More tests.