### PR TITLE
On create not exists class throw `NotFoundException` instead of `ReflectionException`

### DIFF
--- a/src/Definition/ArrayDefinition.php
+++ b/src/Definition/ArrayDefinition.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Factory\Definition;
 
 use Psr\Container\ContainerInterface;
 use Yiisoft\Factory\Exception\InvalidConfigException;
+use Yiisoft\Factory\Exception\NotFoundException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 
 use function count;
@@ -119,6 +120,7 @@ class ArrayDefinition implements DefinitionInterface
     }
 
     /**
+     * @throws NotFoundException
      * @throws NotInstantiableException
      * @throws InvalidConfigException
      */

--- a/src/Definition/ArrayDefinitionBuilder.php
+++ b/src/Definition/ArrayDefinitionBuilder.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Factory\Definition;
 
 use Psr\Container\ContainerInterface;
 use Yiisoft\Factory\Exception\InvalidConfigException;
+use Yiisoft\Factory\Exception\NotFoundException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 
 use function array_key_exists;
@@ -38,6 +39,7 @@ final class ArrayDefinitionBuilder
     }
 
     /**
+     * @throws NotFoundException
      * @throws NotInstantiableException
      * @throws InvalidConfigException
      */
@@ -145,6 +147,9 @@ final class ArrayDefinitionBuilder
      *
      * @return DefinitionInterface[] The dependencies of the specified class.
      * @psalm-return array<string, DefinitionInterface>
+     *
+     * @throws NotFoundException
+     * @throws NotInstantiableException
      */
     private function getDependencies(string $class): array
     {

--- a/src/Definition/ArrayDefinitionBuilder.php
+++ b/src/Definition/ArrayDefinitionBuilder.php
@@ -144,12 +144,11 @@ final class ArrayDefinitionBuilder
      * @param class-string $class Class name or interface name.
      *
      * @throws NotInstantiableException
+     * @throws NotFoundException
+     * @throws NotInstantiableException
      *
      * @return DefinitionInterface[] The dependencies of the specified class.
      * @psalm-return array<string, DefinitionInterface>
-     *
-     * @throws NotFoundException
-     * @throws NotInstantiableException
      */
     private function getDependencies(string $class): array
     {

--- a/src/Definition/DefinitionExtractor.php
+++ b/src/Definition/DefinitionExtractor.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Yiisoft\Factory\Definition;
 
 use ReflectionClass;
+use ReflectionException;
 use ReflectionFunctionAbstract;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionUnionType;
+use Yiisoft\Factory\Exception\NotFoundException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 
 /**
@@ -39,13 +41,22 @@ final class DefinitionExtractor
      *
      * @return DefinitionInterface[]
      * @psalm-return array<string, DefinitionInterface>
+     *
+     * @throws NotFoundException
+     * @throws NotInstantiableException
      */
     public function fromClassName(string $class): array
     {
-        $reflectionClass = new ReflectionClass($class);
+        try {
+            $reflectionClass = new ReflectionClass($class);
+        } catch (ReflectionException $e) {
+            throw new NotFoundException($class);
+        }
+
         if (!$reflectionClass->isInstantiable()) {
             throw new NotInstantiableException($class);
         }
+        
         $constructor = $reflectionClass->getConstructor();
         return $constructor === null ? [] : $this->fromFunction($constructor);
     }

--- a/src/Definition/DefinitionExtractor.php
+++ b/src/Definition/DefinitionExtractor.php
@@ -39,11 +39,11 @@ final class DefinitionExtractor
     /**
      * @psalm-param class-string $class
      *
-     * @return DefinitionInterface[]
-     * @psalm-return array<string, DefinitionInterface>
-     *
      * @throws NotFoundException
      * @throws NotInstantiableException
+     *
+     * @return DefinitionInterface[]
+     * @psalm-return array<string, DefinitionInterface>
      */
     public function fromClassName(string $class): array
     {
@@ -56,7 +56,7 @@ final class DefinitionExtractor
         if (!$reflectionClass->isInstantiable()) {
             throw new NotInstantiableException($class);
         }
-        
+
         $constructor = $reflectionClass->getConstructor();
         return $constructor === null ? [] : $this->fromFunction($constructor);
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -59,11 +59,11 @@ class Factory implements FactoryInterface
     /**
      * @param array|callable|string $config
      *
-     * @return mixed|object
-     *
      * @throws InvalidConfigException
      * @throws NotFoundException
      * @throws NotInstantiableException
+     *
+     * @return mixed|object
      */
     public function create($config)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,6 +10,7 @@ use Yiisoft\Factory\Definition\DefinitionInterface;
 use Yiisoft\Factory\Definition\Normalizer;
 use Yiisoft\Factory\Definition\DefinitionValidator;
 use Yiisoft\Factory\Exception\InvalidConfigException;
+use Yiisoft\Factory\Exception\NotFoundException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 
 class Factory implements FactoryInterface
@@ -55,6 +56,15 @@ class Factory implements FactoryInterface
         $this->setMultiple($definitions);
     }
 
+    /**
+     * @param array|callable|string $config
+     *
+     * @return mixed|object
+     *
+     * @throws InvalidConfigException
+     * @throws NotFoundException
+     * @throws NotInstantiableException
+     */
     public function create($config)
     {
         if ($this->validate) {
@@ -87,6 +97,8 @@ class Factory implements FactoryInterface
     /**
      * @param string $id
      *
+     * @throws InvalidConfigException
+     * @throws NotFoundException
      * @throws NotInstantiableException
      *
      * @return mixed|object

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -11,6 +11,7 @@ use Yiisoft\Factory\Definition\ArrayDefinition;
 use Yiisoft\Factory\Definition\Reference;
 use Yiisoft\Factory\Definition\ValueDefinition;
 use Yiisoft\Factory\Exception\InvalidConfigException;
+use Yiisoft\Factory\Exception\NotFoundException;
 use Yiisoft\Factory\Exception\NotInstantiableException;
 use Yiisoft\Factory\Factory;
 use Yiisoft\Factory\Tests\Support\Car;
@@ -504,5 +505,13 @@ final class FactoryTest extends TestCase
                 new ValueDefinition(new EngineMarkTwo(), 'object'),
             ],
         ]);
+    }
+
+    public function testCreateNonExistsClass(): void
+    {
+        $factory = new Factory();
+
+        $this->expectException(NotFoundException::class);
+        $factory->create('NonExistsClass');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
