### PR TITLE
Factory use ID of array definition as class name if class skipped + Fix bug: factory don't use definitions on resolve dependenices in some cases

### DIFF
--- a/src/DependencyResolver.php
+++ b/src/DependencyResolver.php
@@ -108,7 +108,8 @@ final class DependencyResolver implements DependencyResolverInterface
             return Normalizer::normalize(
                 is_object($this->definitions[$config])
                     ? clone $this->definitions[$config]
-                    : $this->definitions[$config]
+                    : $this->definitions[$config],
+                $config
             );
         }
 

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -667,7 +667,7 @@ final class FactoryTest extends TestCase
         /** @var EngineMarkOne $engine */
         $engine = $factory->create(EngineInterface::class);
 
-        $this->assertSame(0, $engine->getNumber());
+        $this->assertSame(42, $engine->getNumber());
     }
 
     public function testOptionalInterfaceDependency(): void
@@ -1167,5 +1167,21 @@ final class FactoryTest extends TestCase
         $object = $factory->create(Car::class);
 
         $this->assertSame($array, $object->getMoreEngines());
+    }
+
+    public function testArrayDefinitionWithoutClass(): void
+    {
+        $factory = new Factory(
+            null,
+            [
+                Firefighter::class => [
+                    '__construct()' => ['Petr']
+                ],
+            ],
+        );
+
+        $object = $factory->create(Firefighter::class);
+
+        $this->assertSame('Petr', $object->getName());
     }
 }

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -1175,7 +1175,7 @@ final class FactoryTest extends TestCase
             null,
             [
                 Firefighter::class => [
-                    '__construct()' => ['Petr']
+                    '__construct()' => ['Petr'],
                 ],
             ],
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #109 #118
