### PR TITLE
Rename DependencyResolverInterface::resolve() to DependencyResolverInterface::resolveReference()

### DIFF
--- a/src/Definition/Reference.php
+++ b/src/Definition/Reference.php
@@ -54,6 +54,6 @@ final class Reference implements ReferenceInterface
 
     public function resolve(DependencyResolverInterface $container)
     {
-        return $container->resolve($this->id);
+        return $container->resolveReference($this->id);
     }
 }

--- a/src/DependencyResolver.php
+++ b/src/DependencyResolver.php
@@ -72,7 +72,7 @@ final class DependencyResolver implements DependencyResolverInterface
         return $this->canBeCreatedByFactory($id);
     }
 
-    public function resolve(string $id)
+    public function resolveReference(string $id)
     {
         return $this->getFromFactory($id);
     }

--- a/src/DependencyResolverInterface.php
+++ b/src/DependencyResolverInterface.php
@@ -14,7 +14,7 @@ use Psr\Container\NotFoundExceptionInterface;
 interface DependencyResolverInterface extends ContainerInterface
 {
     /**
-     * Resolve a dependency with an ID specified.
+     * Resolve a reference with an ID specified.
      *
      * @param string $id Identifier of the entry to look for.
      *
@@ -25,7 +25,7 @@ interface DependencyResolverInterface extends ContainerInterface
      *
      * @psalm-suppress InvalidThrow
      */
-    public function resolve(string $id);
+    public function resolveReference(string $id);
 
     /**
      * Invoke a callable resolving dependencies based on its signature.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

Adopt PR: https://github.com/yiisoft/di/pull/236