### PR TITLE
Deny use instance of `DefinitionInterface` (exclude `ReferenceInterface`) as definition or constructor argument

### DIFF
--- a/src/Definition/DefinitionResolver.php
+++ b/src/Definition/DefinitionResolver.php
@@ -76,7 +76,7 @@ final class DefinitionResolver
 
         if ($value instanceof DefinitionInterface) {
             throw new InvalidConfigException(
-                'Only references are allowed in parameters, a definition object was provided: ' .
+                'Only references are allowed in constructor arguments, a definition object was provided: ' .
                 var_export($value, true)
             );
         }

--- a/src/Definition/DefinitionValidator.php
+++ b/src/Definition/DefinitionValidator.php
@@ -23,7 +23,7 @@ final class DefinitionValidator
     public static function validate($definition, ?string $id = null): void
     {
         // Reference or ready object
-        if (is_object($definition)) {
+        if (is_object($definition) && self::isValidObject($definition)) {
             return;
         }
 
@@ -87,6 +87,15 @@ final class DefinitionValidator
                         )
                     );
                 }
+                /** @var mixed $argument */
+                foreach ($value as $argument) {
+                    if (is_object($argument) && !self::isValidObject($argument)) {
+                        throw new InvalidConfigException(
+                            'Only references are allowed in constructor arguments, a definition object was provided: ' .
+                            var_export($argument, true)
+                        );
+                    }
+                }
                 continue;
             }
 
@@ -138,6 +147,14 @@ final class DefinitionValidator
                 $preparedKey
             )
         );
+    }
+
+    /**
+     * Deny DefinitionInterface, exclude ReferenceInterface
+     */
+    private static function isValidObject(object $value): bool
+    {
+        return !($value instanceof DefinitionInterface) || $value instanceof ReferenceInterface;
     }
 
     /**

--- a/src/Definition/Normalizer.php
+++ b/src/Definition/Normalizer.php
@@ -80,7 +80,7 @@ final class Normalizer
         }
 
         // Ready object
-        if (is_object($definition)) {
+        if (is_object($definition) && !($definition instanceof DefinitionInterface)) {
             return new ValueDefinition($definition);
         }
 

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -1238,7 +1238,7 @@ final class FactoryTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches(
-            '~^Only references are allowed in constructor arguments, a definition object was provided: '            .
+            '~^Only references are allowed in constructor arguments, a definition object was provided: ' .
             'Yiisoft\\\\Factory\\\\Definition\\\\ValueDefinition::~'
         );
         new Factory(null, ['test' => $definition]);

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -546,7 +546,7 @@ final class FactoryTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches(
-            '/^Only references are allowed in parameters, a definition object was provided:/'
+            '/^Only references are allowed in constructor arguments, a definition object was provided:/'
         );
         $factory->create([
             'class' => Car::class,
@@ -583,7 +583,7 @@ final class FactoryTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches(
-            '~^Only references are allowed in parameters, a definition object was provided: ' .
+            '~^Only references are allowed in constructor arguments, a definition object was provided: ' .
             'Yiisoft\\\\Factory\\\\Definition\\\\ArrayDefinition::~'
         );
         $factory->create([
@@ -1205,5 +1205,55 @@ final class FactoryTest extends TestCase
         $cube = $factory->create(Cube::class);
 
         $this->assertSame($color, $cube->getColor());
+    }
+
+    public function testDefinitionInterfaceAsDefinition(): void
+    {
+        $definition = ArrayDefinition::fromConfig([
+            'class' => stdClass::class,
+        ]);
+
+        $this->expectException(InvalidConfigException::class);
+        new Factory(null, ['test' => $definition]);
+    }
+
+    public function testDefinitionInterfaceAsDefinitionWithoutValidation(): void
+    {
+        $definition = ArrayDefinition::fromConfig([
+            'class' => stdClass::class,
+        ]);
+
+        $factory = new Factory(null, ['test' => $definition], false);
+
+        $this->expectException(InvalidConfigException::class);
+        $factory->create('test');
+    }
+
+    public function testDefinitionInterfaceAsDefinitionInConstructorArguments(): void
+    {
+        $definition = [
+            'class' => Cube::class,
+            '__construct()' => [new ValueDefinition(new ColorPink())],
+        ];
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessageMatches(
+            '~^Only references are allowed in constructor arguments, a definition object was provided: '            .
+            'Yiisoft\\\\Factory\\\\Definition\\\\ValueDefinition::~'
+        );
+        new Factory(null, ['test' => $definition]);
+    }
+
+    public function testDefinitionInterfaceAsDefinitionInConstructorArgumentsWithoutValidation(): void
+    {
+        $definition = [
+            'class' => Cube::class,
+            '__construct()' => [new ValueDefinition(new ColorPink())],
+        ];
+
+        $factory = new Factory(null, ['test' => $definition], false);
+
+        $this->expectException(InvalidConfigException::class);
+        $factory->create('test');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #110 

Adopt PR: https://github.com/yiisoft/di/pull/238

Test pass in demo app.