### PR TITLE
Cleanup references

### DIFF
--- a/src/Definition/DynamicReference.php
+++ b/src/Definition/DynamicReference.php
@@ -11,14 +11,12 @@ use function is_callable;
 use function is_object;
 
 /**
- * Class DynamicReference allows us to define a dependency to a service not defined in the container.
- * Definition may be defined multiple ways {@see Normalizer}.
- * For example:
+ * The `DynamicReference` defines a dependency to a service not defined in the container.
+ * Definition may be defined multiple ways ({@see Normalizer}). For example:
+ *
  * ```php
  * [
- *    InterfaceA::class => ConcreteA::class,
- *    'alternativeForA' => ConcreteB::class,
- *    Service1::class => [
+ *    MyService::class => [
  *        '__construct()' => [
  *            DynamicReference::to([
  *                'class' => SomeClass::class,
@@ -50,9 +48,9 @@ final class DynamicReference implements ReferenceInterface
     /**
      * @see Normalizer
      *
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException If definition is not valid.
      */
-    public static function to($id): ReferenceInterface
+    public static function to($id): self
     {
         return new self($id);
     }

--- a/src/Definition/Reference.php
+++ b/src/Definition/Reference.php
@@ -10,17 +10,18 @@ use Yiisoft\Factory\DependencyResolverInterface;
 use function is_string;
 
 /**
- * Class Reference allows us to define a dependency to a service in the container in another service definition.
+ * The `Reference` defines a dependency to a service in the container or factory in another service definition.
  * For example:
+ *
  * ```php
  * [
  *    InterfaceA::class => ConcreteA::class,
  *    'alternativeForA' => ConcreteB::class,
- *    Service1::class => [
+ *    MyService::class => [
  *        '__construct()' => [
- *            Reference::to('alternativeForA')
- *        ]
- *    ]
+ *            Reference::to('alternativeForA'),
+ *        ],
+ *    ],
  * ]
  * ```
  */
@@ -33,20 +34,13 @@ final class Reference implements ReferenceInterface
         $this->id = $id;
     }
 
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
     /**
-     * @param mixed $id
-     *
-     * @throws InvalidConfigException
+     * @throws InvalidConfigException If ID is not string.
      */
-    public static function to($id): ReferenceInterface
+    public static function to($id): self
     {
         if (!is_string($id)) {
-            throw new InvalidConfigException('Reference id must be string.');
+            throw new InvalidConfigException('Reference ID must be string.');
         }
 
         return new self($id);

--- a/tests/Unit/Definition/ReferenceTest.php
+++ b/tests/Unit/Definition/ReferenceTest.php
@@ -9,17 +9,8 @@ use Yiisoft\Factory\Definition\Reference;
 use Yiisoft\Factory\Exception\InvalidConfigException;
 use Yiisoft\Factory\Tests\Support\EngineInterface;
 
-/**
- * ReferenceTest contains tests for Yiisoft\Factory\Definition\Reference
- */
 final class ReferenceTest extends TestCase
 {
-    public function testTo(): void
-    {
-        $ref = Reference::to(EngineInterface::class);
-        $this->assertSame(EngineInterface::class, $ref->getId());
-    }
-
     public function testInvalid(): void
     {
         $this->expectException(InvalidConfigException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

- Removed not used `Reference::getId()`
- Improve doc-blocks
- Change type of return value in `Reference::to()` and `DynamicReference::to()` to `self`
